### PR TITLE
Update Notebook Backgrounds.css

### DIFF
--- a/Notebook Backgrounds.css
+++ b/Notebook Backgrounds.css
@@ -36,8 +36,8 @@ https://angel-rs.github.io/css-color-filter-generator
 }
 
 /* Recolors images on the page with the current accent color. */
-.recolor-images img {
-  filter: var(--image-effect);
+.recolor-images img:not([src*=".jpeg"]):not([src*=".jpg"]):not([src*=".bmp"]):not([src*=".tiff"]):not([src*=".webp"]) {
+    filter: var(--image-effect);
 }
 
 /* ---------------------------- Page Backgrounds ---------------------------- */


### PR DESCRIPTION
**Image Recoloring Rule Updated**: Added a filter to exclude images in formats that do not support transparency (e.g., .jpg, .jpeg, .bmp, .tiff, .webp)
**Issue Resolved**: Prevented transparency effects from being incorrectly applied to non-transparent image formats, which resulted in improper recoloring.