### PR TITLE
Improved Compatibility and Styling Consistency for Theme-Independent Elements

### DIFF
--- a/Notebook Backgrounds.css
+++ b/Notebook Backgrounds.css
@@ -213,6 +213,12 @@ https://angel-rs.github.io/css-color-filter-generator
   --code-background: color-mix(in srgb, var(--background-primary, #ffffff) 80%, black) !important;
 }
 
+/* Tables */
+:is(.pen-white, .pen-blue, .pen-red, .pen-green, .pen-black, .pen-gray, .pen-purple) table th {
+  color: var(--accent-color);
+  font-weight: bold;
+}
+
 /* ------------------------------- Pen Colors ------------------------------- */
 
 .pen-white {

--- a/Notebook Backgrounds.css
+++ b/Notebook Backgrounds.css
@@ -186,7 +186,7 @@ https://angel-rs.github.io/css-color-filter-generator
     .pen-purple
   )
   :is(.callout > .callout-title, svg) {
-  color: color-mix(in srgb, var(--accent-color) 60%, transparent) ;
+  color: color-mix(in srgb, var(--accent-color) 60%, transparent);
 }
 
 /* Code Blocks */
@@ -209,7 +209,7 @@ https://angel-rs.github.io/css-color-filter-generator
 
 :is(.pen-white, .pen-blue, .pen-red, .pen-green, .pen-black, .pen-gray, .pen-purple):not(.page-manila):not(.page-white):not(.page-blueprint) :is(code, .HyperMD-codeblock, .cm-inline-code) {
   --code-normal: var(--accent-color);
-  --code-background: color-mix(in srgb, var(--background-primary, #ffffff) 80%, black) !important;
+  
 }
 
 /* Tables */

--- a/Notebook Backgrounds.css
+++ b/Notebook Backgrounds.css
@@ -189,6 +189,10 @@ https://angel-rs.github.io/css-color-filter-generator
   color: color-mix(in srgb, var(--accent-color) 60%, transparent);
 }
 
+.callout {
+    --callout-blend-mode: normal; 
+}
+
 /* Code Blocks */
 :is(.page-white, .page-manila, .page-blueprint) :is(code,
 .HyperMD-codeblock, .cm-inline-code) {

--- a/Notebook Backgrounds.css
+++ b/Notebook Backgrounds.css
@@ -199,7 +199,7 @@ https://angel-rs.github.io/css-color-filter-generator
     black
   ) !important;
 }
-div > pre {
+:is(.page-white, .page-manila, .page-blueprint) div > pre {
   --code-background: color-mix(
     in srgb,
     var(--page-color) 80%,

--- a/Notebook Backgrounds.css
+++ b/Notebook Backgrounds.css
@@ -72,6 +72,7 @@ https://angel-rs.github.io/css-color-filter-generator
   --interactive-accent: var(--accent-color);
   --metadata-label-text-color: var(--accent-color);
   --metadata-input-text-color: var(--accent-color);
+  --metadata-input-background-active: var(--accent-color-trans);
   --tag-color: var(--accent-color);
   --tag-background: var(--accent-color-trans);
   --pill-cover-hover: color-mix(in srgb, var(--accent-color) 60%, transparent);
@@ -185,7 +186,7 @@ https://angel-rs.github.io/css-color-filter-generator
     .pen-gray,
     .pen-purple
   )
-  svg {
+  :is(.callout > .callout-title, svg) {
   color: color-mix(in srgb, var(--accent-color) 60%, transparent);
 }
 
@@ -207,8 +208,9 @@ https://angel-rs.github.io/css-color-filter-generator
   ) !important;
 }
 
-:is(.page-white, .page-manila, .page-blueprint) {
-  --metadata-input-background-active: var(--accent-color-trans);
+:is(.pen-white, .pen-blue, .pen-red, .pen-green, .pen-black, .pen-gray, .pen-purple):not(.page-manila):not(.page-white):not(.page-blueprint) :is(code, .HyperMD-codeblock, .cm-inline-code) {
+  --code-normal: var(--accent-color);
+  --code-background: color-mix(in srgb, var(--background-primary, #ffffff) 80%, black) !important;
 }
 
 /* ------------------------------- Pen Colors ------------------------------- */

--- a/Notebook Backgrounds.css
+++ b/Notebook Backgrounds.css
@@ -86,7 +86,6 @@ https://angel-rs.github.io/css-color-filter-generator
 
   color: var(--accent-color);
   background-color: var(--page-color);
-  font-weight: bold;
 }
 
 /* ----------------------- Manila/Tan Page Background ----------------------- */
@@ -187,7 +186,7 @@ https://angel-rs.github.io/css-color-filter-generator
     .pen-purple
   )
   :is(.callout > .callout-title, svg) {
-  color: color-mix(in srgb, var(--accent-color) 60%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 60%, transparent) ;
 }
 
 /* Code Blocks */
@@ -276,4 +275,8 @@ https://angel-rs.github.io/css-color-filter-generator
   --hr-color: var(--accent-color);
   --image-effect: brightness(0) saturate(100%) invert(33%) sepia(59%)
     saturate(2620%) hue-rotate(249deg) brightness(98%) contrast(93%);
+}
+
+.pen-white, .pen-blue, .pen-red, .pen-green, .pen-black, .pen-gray, .pen-purple {
+  --checklist-done-color: var(--accent-color);
 }


### PR DESCRIPTION
I’ve fixed a few issues I found while using the snippet in my personal Obsidian setup. Since I rely on it daily, I wanted to contribute by improving several aspects:
- Table headers are now colored correctly based on the selected pen, regardless of whether a theme is active.
- The same applies to code blocks — their text color now matches the selected pen color even when no theme is active.
- Fixed the rendering of code blocks in Reading View.
- Callout titles and icons now also inherit the selected pen color when no theme is active.
- Other small refinements and visual consistency improvements.